### PR TITLE
Update providers.tf - hashicorp->oracle

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     oci = {
-      source  = "hashicorp/oci"
+      source  = "oracle/oci"
       version = "4.69.0"
     }
   }


### PR DESCRIPTION
Got a warning that when using terraform > 0.13 I should use oracle/oci instead of hashicorp/oci ... I guess that will pally to most users?